### PR TITLE
Fix use of obsolete member

### DIFF
--- a/ICSharpCode.NRefactory.Cecil/CecilLoader.cs
+++ b/ICSharpCode.NRefactory.Cecil/CecilLoader.cs
@@ -182,7 +182,7 @@ namespace ICSharpCode.NRefactory.TypeSystem
 			moduleAttributes = interningProvider.InternList(moduleAttributes);
 			
 			this.currentAssembly = new CecilUnresolvedAssembly(assemblyDefinition != null ? assemblyDefinition.Name.FullName : moduleDefinition.Name, this.DocumentationProvider);
-			currentAssembly.Location = moduleDefinition.FullyQualifiedName;
+			currentAssembly.Location = moduleDefinition.FileName;
 			currentAssembly.AssemblyAttributes.AddRange(assemblyAttributes);
 			currentAssembly.ModuleAttributes.AddRange(assemblyAttributes);
 			


### PR DESCRIPTION
They return the same underlying field, see https://github.com/jbevain/cecil/blob/d820a5beca4104364178c61e1c59718fb228589e/Mono.Cecil/ModuleDefinition.cs#L333-L340.